### PR TITLE
feat(env): add --mount-src-path for explicit host src override

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,28 @@ sudo uv run mw env list
 sudo uv run mw env rm --all
 ```
 
+### 5. 使用上游 MobileWorld 源码（可选）
+
+ClawGUI-Server 当前 vendored 了一份 [MobileWorld](https://github.com/Tongyi-MAI/MobileWorld) 源码。如果上游已修复了某个 bug 但 Docker 镜像还未发布新 tag，可以通过 `--mount-src-path` 把上游 `src` 直接挂进容器，**无需切换工作目录**：
+
+```bash
+# 第一步：克隆 MobileWorld（与 ClawGUI-Server 平级即可，路径任意）
+git clone https://github.com/Tongyi-MAI/MobileWorld.git /path/to/MobileWorld
+
+# 第二步：在 ClawGUI-Server 目录下用 --mount-src-path 启动容器
+uv run mw env run \
+    --count 1 \
+    --mount-src-path /path/to/MobileWorld/src \
+    --backend-start-port 7000 \
+    --viewer-start-port 8000 \
+    --vnc-start-port 5900 \
+    --adb-start-port 5600
+```
+
+容器内的 `/app/service/src` 会被替换为你指定的 MobileWorld `src/`，重启容器内 server 即可生效。
+
+> 与 `--mount-src` 的区别：`--mount-src` 通过当前 cwd 向上查找 `pyproject.toml` 自动挂载本仓库的 `src/`；`--mount-src-path` 显式指定路径，适合"挂上游 / 挂另一个 worktree"等场景。两者都不会启用 `--dev` 隐含的 VNC 与单容器限制。
+
 ## 模型部署
 
 使用 vLLM 部署模型服务，示例脚本在 `scripts/` 目录下：

--- a/README_EN.md
+++ b/README_EN.md
@@ -103,6 +103,28 @@ sudo uv run mw env list
 sudo uv run mw env rm --all
 ```
 
+### 5. Use Upstream MobileWorld Source (Optional)
+
+ClawGUI-Server currently vendors a copy of [MobileWorld](https://github.com/Tongyi-MAI/MobileWorld). If a bug is already fixed upstream but no new Docker image tag has been published, you can mount the upstream `src` directly into the container with `--mount-src-path`, **without changing your working directory**:
+
+```bash
+# Step 1: clone MobileWorld anywhere (sibling to ClawGUI-Server is convenient)
+git clone https://github.com/Tongyi-MAI/MobileWorld.git /path/to/MobileWorld
+
+# Step 2: launch from ClawGUI-Server with --mount-src-path
+uv run mw env run \
+    --count 1 \
+    --mount-src-path /path/to/MobileWorld/src \
+    --backend-start-port 7000 \
+    --viewer-start-port 8000 \
+    --vnc-start-port 5900 \
+    --adb-start-port 5600
+```
+
+`/app/service/src` inside the container is overlaid with the MobileWorld `src/` you specified — restart the in-container server to pick up changes.
+
+> Difference from `--mount-src`: `--mount-src` walks up from `cwd` to find `pyproject.toml` and mounts this repo's own `src/`; `--mount-src-path` takes an explicit host path — useful for mounting upstream code, another worktree, or any non-default location. Neither implies `--dev` (no auto VNC, no single-container restriction).
+
 ## Model Deployment
 
 Deploy model services using vLLM. Example scripts are in the `scripts/` directory:

--- a/docs/development.md
+++ b/docs/development.md
@@ -22,6 +22,16 @@ This will:
 
 **Note:** Dev mode only supports launching a single container. If you need multiple containers, launch them separately without dev mode.
 
+### Mounting an Explicit Source Path
+
+When you want to mount a `src` directory that is **not** under the current working directory's project root — for example, the upstream [MobileWorld](https://github.com/Tongyi-MAI/MobileWorld) source while you're inside ClawGUI-Server — pass the path explicitly:
+
+```bash
+mw env run --mount-src-path /path/to/MobileWorld/src
+```
+
+The path must point to the `src` folder itself (not the repo root). It overrides `--mount-src` auto-detection when both are given. Errors are hard failures (the command exits) rather than silent warnings, so a typo won't quietly fall back to the default mount.
+
 ### Restarting the Server
 
 When you make code changes in dev mode, you need to restart the server for changes to take effect:

--- a/src/mobile_world/core/subcommands/env.py
+++ b/src/mobile_world/core/subcommands/env.py
@@ -177,6 +177,18 @@ def configure_parser(subparsers: argparse._SubParsersAction) -> None:
         help="Mount local src directory to container",
     )
     launch_parser.add_argument(
+        "--mount-src-path",
+        "--mount_src_path",
+        dest="mount_src_path",
+        type=str,
+        default=None,
+        help=(
+            "Explicit host src directory to mount to /app/service/src. "
+            "Must point to the 'src' folder itself, e.g. /path/to/MobileWorld/src. "
+            "Overrides --mount-src auto-detection when both are given."
+        ),
+    )
+    launch_parser.add_argument(
         "--launch-interval",
         "--launch_interval",
         dest="launch_interval",
@@ -389,6 +401,30 @@ def _launch_containers(args: argparse.Namespace) -> None:
                     border_style="yellow",
                 )
             )
+
+    # Handle explicit --mount-src-path: overrides auto-detected dev_src_path above
+    if args.mount_src_path:
+        explicit_path = Path(args.mount_src_path).expanduser()
+        if not explicit_path.is_absolute():
+            explicit_path = current_path / explicit_path
+        explicit_path = explicit_path.resolve()
+        if not explicit_path.is_dir():
+            console.print(
+                Panel(
+                    f"[red]--mount-src-path is not an existing directory: {explicit_path}[/red]",
+                    title="[red]✗ Error[/red]",
+                    border_style="red",
+                )
+            )
+            sys.exit(1)
+        dev_src_path = explicit_path
+        console.print(
+            Panel(
+                f"[green]Source mount enabled[/green]\n[cyan]Mounting:[/cyan] {dev_src_path} → /app/service/src",
+                title="[green]📦 Source Mount[/green]",
+                border_style="green",
+            )
+        )
 
     # Handle .env file mounting
     env_file_path = None


### PR DESCRIPTION
Allows mounting an explicit host directory (e.g. an upstream MobileWorld
checkout) into /app/service/src without relying on cwd's pyproject.toml.
The original --mount-src auto-detection is preserved unchanged.

- argparse: new --mount-src-path / --mount_src_path option
- launch flow: explicit path takes precedence; missing dir is a hard
  failure (sys.exit(1)) instead of a silent warning
- relative paths are resolved against cwd; absolute paths are also
  normalized (symlinks, ..)
- mount status panel now distinguishes Dev Mode vs Source Mount
- docs: README (zh/en) and docs/development.md updated with usage

Tested: dry-run with `mw env run --mount-src-path /path/to/MobileWorld/src`
verified that the resulting `docker run` command contains
`-v /path/to/MobileWorld/src:/app/service/src`. Negative cases
(non-existent path, file-not-directory) exit 1 as expected.
Pre-existing --mount-src and --dev paths produce unchanged output.